### PR TITLE
fix id3 deprecated function Tag::read_from to Tag::read_from2

### DIFF
--- a/crates/ncmdump-bin/src/metadata.rs
+++ b/crates/ncmdump-bin/src/metadata.rs
@@ -17,7 +17,8 @@ pub(crate) struct Mp3Metadata(id3::Tag);
 
 impl Mp3Metadata {
     pub(crate) fn new(info: &NcmInfo, image: &[u8], data: &[u8]) -> Self {
-        let mut tag = id3::Tag::read_from(data).unwrap_or_else(|_| id3::Tag::new());
+        let cursor = Cursor::new(data.to_vec());
+        let mut tag = id3::Tag::read_from2(cursor).unwrap_or_else(|_| id3::Tag::new());
         let artist = info
             .artist
             .iter()


### PR DESCRIPTION
add a cursor to store data and then replace read_from to read_from2 by passing cursor