### PR TITLE
修正云音乐 v3.0 Mac 生成的 NCM 文件 + 代码重构

### DIFF
--- a/crates/ncmdump-bin/src/metadata.rs
+++ b/crates/ncmdump-bin/src/metadata.rs
@@ -1,8 +1,8 @@
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
 use anyhow::Result;
-use id3::{TagLike, Version};
 use id3::frame::Picture;
+use id3::{TagLike, Version};
 
 use ncmdump::NcmInfo;
 
@@ -65,11 +65,13 @@ impl FlacMetadata {
         mc.set_title(vec![info.name.to_string()]);
         mc.set_album(vec![info.album.to_string()]);
         mc.set_artist(artist);
-        tag.add_picture(
-            get_image_mime_type(image),
-            metaflac::block::PictureType::CoverFront,
-            image.to_vec(),
-        );
+        if !image.is_empty() {
+            tag.add_picture(
+                get_image_mime_type(image),
+                metaflac::block::PictureType::CoverFront,
+                image.to_vec(),
+            );
+        }
         Self(tag)
     }
 }

--- a/crates/ncmdump-bin/src/utils.rs
+++ b/crates/ncmdump-bin/src/utils.rs
@@ -1,4 +1,8 @@
 pub(crate) fn get_image_mime_type(bytes: &[u8]) -> &'static str {
+    if bytes.len() < 12 {
+        return "image/*";
+    }
+
     match &bytes[..12] {
         [0x89, 0x50, 0x4e, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, ..] => "image/png",
         [0xFF, 0xD8, 0xFF, 0xE0 | 0xE1 | 0xE2 | 0xE3 | 0xE8, ..] => "image/jpeg",


### PR DESCRIPTION
修正了云音乐 v3.0 Mac 生成的 ncm 封面格式问题（测试文件参考 https://github.com/taurusxin/ncmdump/issues/26 的附件），以及重构了部分代码。