### PR TITLE
Make the `glob` dependency only required under Windows

### DIFF
--- a/crates/ncmdump-bin/Cargo.toml
+++ b/crates/ncmdump-bin/Cargo.toml
@@ -20,9 +20,11 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { version = "^4.1", features = ["derive"] }
 crossbeam-channel = "^0.5"
-glob = "^0.3"
 indicatif = "^0.17"
 thiserror = { workspace = true }
 ncmdump = { workspace = true }
 metaflac = "0.2.5"
 id3 = "1.9.0"
+
+[target.'cfg(windows)'.dependencies]
+glob = "^0.3"

--- a/crates/ncmdump-bin/src/command.rs
+++ b/crates/ncmdump-bin/src/command.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use glob::glob;
+
 use crate::errors::Error;
 
 #[derive(Clone, Debug, Default, Parser)]
@@ -43,10 +43,10 @@ impl Command {
     }
 
     #[cfg(target_os = "windows")]
-    pub(crate) fn items(&self) -> std::result::Result<Vec<PathBuf>, Error> {
+    pub(crate) fn items(&self) -> Result<Vec<PathBuf>, Error> {
         let mut paths = Vec::new();
         for matcher in &self.matchers {
-            for entry in glob(matcher)? {
+            for entry in glob::glob(matcher)? {
                 let path = entry?;
                 if !path.is_file() {
                     continue;

--- a/crates/ncmdump-bin/src/errors.rs
+++ b/crates/ncmdump-bin/src/errors.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use glob::{GlobError, PatternError};
 use ncmdump::error::Errors;
 use thiserror::Error;
 
@@ -20,14 +19,16 @@ pub enum Error {
     Dump(String),
 }
 
-impl From<PatternError> for Error {
-    fn from(_: PatternError) -> Self {
+#[cfg(target_os = "windows")]
+impl From<glob::PatternError> for Error {
+    fn from(_: glob::PatternError) -> Self {
         Self::Path
     }
 }
 
-impl From<GlobError> for Error {
-    fn from(_: GlobError) -> Self {
+#[cfg(target_os = "windows")]
+impl From<glob::GlobError> for Error {
+    fn from(_: glob::GlobError) -> Self {
         Self::Path
     }
 }


### PR DESCRIPTION
`glob` is only used on Windows target, but it will be download on all targets, this PR fixes this issue.